### PR TITLE
SB-94 (feat) : Pet 조회 이미지 로직

### DIFF
--- a/db/src/main/java/db/domain/image/ImageRepository.java
+++ b/db/src/main/java/db/domain/image/ImageRepository.java
@@ -9,4 +9,6 @@ public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
 
     boolean existsByIdAndUserId(Long imageId, Long userId);
 
+    Optional<ImageEntity> findFirstByPetIdOrderByIdDesc(Long petId);
+
 }

--- a/pet/src/main/java/pet/domain/image/controller/model/ImageResponse.java
+++ b/pet/src/main/java/pet/domain/image/controller/model/ImageResponse.java
@@ -1,0 +1,23 @@
+package pet.domain.image.controller.model;
+
+import db.domain.image.enums.ImageKind;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ImageResponse {
+
+    private Long id;
+
+    private String imageUrl;
+
+    private ImageKind kind;
+
+    private Long userId;
+
+}

--- a/pet/src/main/java/pet/domain/image/converter/ImageConverter.java
+++ b/pet/src/main/java/pet/domain/image/converter/ImageConverter.java
@@ -1,0 +1,21 @@
+package pet.domain.image.converter;
+
+import db.domain.image.ImageEntity;
+import global.annotation.Converter;
+import lombok.extern.slf4j.Slf4j;
+import pet.domain.image.controller.model.ImageResponse;
+
+@Converter
+@Slf4j
+public class ImageConverter {
+
+    public ImageResponse toResponse(ImageEntity imageEntity) {
+        return ImageResponse.builder()
+            .id(imageEntity.getId())
+            .imageUrl(imageEntity.getImageUrl())
+            .kind(imageEntity.getKind())
+            .userId(imageEntity.getUserId())
+            .build();
+    }
+
+}

--- a/pet/src/main/java/pet/domain/image/service/ImageService.java
+++ b/pet/src/main/java/pet/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package pet.domain.image.service;
 
+import db.domain.image.ImageEntity;
 import db.domain.image.ImageRepository;
 import db.domain.pet.PetEntity;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,10 @@ public class ImageService {
                     return imageRepository.save(imageEntity);
                 }).orElseThrow(() -> new ImageNotFoundException(ImageErrorCode.IMAGE_NOT_FOUND));
         }
+    }
+
+    public ImageEntity getImageOrNullBy(Long petId) {
+        return imageRepository.findFirstByPetIdOrderByIdDesc(petId).orElse(null);
     }
 
 }

--- a/pet/src/main/java/pet/domain/pet/controller/model/detail/PetDetailResponse.java
+++ b/pet/src/main/java/pet/domain/pet/controller/model/detail/PetDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pet.domain.image.controller.model.ImageResponse;
 
 @Data
 @NoArgsConstructor
@@ -27,5 +28,7 @@ public class PetDetailResponse {
     private float weight;
 
     private Long userId;
+
+    private ImageResponse petImage;
 
 }

--- a/pet/src/main/java/pet/domain/pet/controller/model/detail/PetListResponse.java
+++ b/pet/src/main/java/pet/domain/pet/controller/model/detail/PetListResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pet.domain.image.controller.model.ImageResponse;
 
 @Data
 @NoArgsConstructor
@@ -18,5 +19,7 @@ public class PetListResponse {
     private String name;
 
     private PetCategory category;
+
+    private ImageResponse petImage;
 
 }

--- a/pet/src/main/java/pet/domain/pet/converter/PetConverter.java
+++ b/pet/src/main/java/pet/domain/pet/converter/PetConverter.java
@@ -5,6 +5,7 @@ import db.domain.pet.enums.PetStatus;
 import global.annotation.Converter;
 import java.time.LocalDateTime;
 import java.util.List;
+import pet.domain.image.controller.model.ImageResponse;
 import pet.domain.pet.controller.model.detail.PetDetailResponse;
 import pet.domain.pet.controller.model.detail.PetListResponse;
 import pet.domain.pet.controller.model.register.PetRegisterRequest;
@@ -34,7 +35,7 @@ public class PetConverter {
             .build();
     }
 
-    public PetDetailResponse toDetailResponse(PetEntity petEntity) {
+    public PetDetailResponse toDetailResponse(PetEntity petEntity, ImageResponse imageResponse) {
         return PetDetailResponse.builder()
             .petId(petEntity.getId())
             .name(petEntity.getName())
@@ -43,14 +44,16 @@ public class PetConverter {
             .category(petEntity.getCategory())
             .weight(petEntity.getWeight())
             .userId(petEntity.getUserId())
+            .petImage(imageResponse)
             .build();
     }
 
-    public PetListResponse toListResponse(PetEntity petEntity) {
+    public PetListResponse toListResponse(PetEntity petEntity, ImageResponse imageResponse) {
         return PetListResponse.builder()
             .petId(petEntity.getId())
             .name(petEntity.getName())
             .category(petEntity.getCategory())
+            .petImage(imageResponse)
             .build();
     }
 }


### PR DESCRIPTION
# SB-94 (feat) : Pet 조회 이미지 로직 추가

- `Pet` 단일 조회 및 리스트 조회시 해당하는 `Pet` 의 `Image` 를 같이 조회하도록 변경
- 이미지가 등록되지 않은 경우 NULL

## 변경 후 Response Spec
### 단일 조회
```
{
    "result": {
        "resultCode": 200,
        "resultMessage": "성공",
        "resultDescription": "성공"
    },
    "body": {
        "petId": 0,
        "name": "string",
        "birth": "2018-09-09",
        "address": "string",
        "category": "DOG",
        "weight": 0,
        "userId": 0,
        "petImage": {
            "id": 0,
            "imageUrl": "string",
            "kind": "PET",
            "userId": 0
        }
    }
}
```
### 리스트 조회
```
{
    "result": {
        "resultCode": 200,
        "resultMessage": "성공",
        "resultDescription": "성공"
    },
    "body": [
        {
            "petId": 0,
            "name": "string",
            "category": "DOG",
            "petImage" : null
        },
        {
            "petId": 0,
            "name": "string",
            "category": "DOG",
            "petImage": {
                "id": 0,
                "imageUrl": "string",
                "kind": "PET",
                "userId": 0
            }
        }
    ]
}
```