### PR TITLE
SB-97 (feat) : 단일 Board 응답에 이미지 응답 정보 추가

### DIFF
--- a/board/src/main/java/board/domain/board/business/BoardBusiness.java
+++ b/board/src/main/java/board/domain/board/business/BoardBusiness.java
@@ -12,9 +12,12 @@ import board.domain.board.converter.BoardConverter;
 import board.domain.board.service.BoardService;
 import board.domain.comment.converter.CommentConverter;
 import board.domain.comment.service.CommentService;
+import board.domain.image.controller.model.ImageResponse;
+import board.domain.image.converter.ImageConverter;
 import board.domain.image.service.ImageService;
 import db.domain.board.BoardEntity;
 import db.domain.comment.CommentEntity;
+import db.domain.image.ImageEntity;
 import global.annotation.Business;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +32,7 @@ public class BoardBusiness {
     private final BoardConverter boardConverter;
     private final CommentConverter commentConverter;
     private final MessageConverter messageConverter;
+    private final ImageConverter imageConverter;
 
     public BoardRegisterResponse register(BoardRegisterRequest request, Long userId) {
 
@@ -70,12 +74,18 @@ public class BoardBusiness {
         // 게시글 Entity 조회
         BoardEntity boardEntity = boardService.getBoardBy(boardId);
 
+        // 이미지 Entity 조회
+        List<ImageEntity> imageEntityList = imageService.getImageOrEmptyBy(boardId);
+        List<ImageResponse> imageResponseList = imageEntityList.stream()
+            .map(imageEntity -> imageConverter.toResponse(imageEntity))
+            .toList();
+
         // 해당하는 게시글에 대한 댓글 리스트 조회, EMPTY 인 경우가 존재함
         List<CommentEntity> commentEntityList = commentService.getCommentListBy(boardId);
         List<CommentDetailResponse> commentDetailList = commentConverter.toResponse(
             commentEntityList);
 
-        return boardConverter.toResponse(boardEntity, commentDetailList);
+        return boardConverter.toResponse(boardEntity, imageResponseList, commentDetailList);
     }
 
 }

--- a/board/src/main/java/board/domain/board/controller/model/detail/BoardDetailResponse.java
+++ b/board/src/main/java/board/domain/board/controller/model/detail/BoardDetailResponse.java
@@ -1,5 +1,6 @@
 package board.domain.board.controller.model.detail;
 
+import board.domain.image.controller.model.ImageResponse;
 import db.domain.board.enums.BoardStatus;
 import db.domain.pet.enums.PetCategory;
 import java.time.LocalDateTime;
@@ -32,5 +33,7 @@ public class BoardDetailResponse {
     private Long userId;
 
     private List<CommentDetailResponse> commentList;
+
+    private List<ImageResponse> boardImage;
 
 }

--- a/board/src/main/java/board/domain/board/converter/BoardConverter.java
+++ b/board/src/main/java/board/domain/board/converter/BoardConverter.java
@@ -5,8 +5,10 @@ import board.domain.board.controller.model.detail.CommentDetailResponse;
 import board.domain.board.controller.model.register.BoardRegisterRequest;
 import board.domain.board.controller.model.register.BoardRegisterResponse;
 import board.domain.board.controller.model.update.BoardUpdateResponse;
+import board.domain.image.controller.model.ImageResponse;
 import db.domain.board.BoardEntity;
 import db.domain.comment.CommentEntity;
+import db.domain.image.ImageEntity;
 import global.annotation.Converter;
 import java.util.List;
 
@@ -22,8 +24,11 @@ public class BoardConverter {
 
     }
 
-    public BoardDetailResponse toResponse(BoardEntity boardEntity,
-        List<CommentDetailResponse> commentDetailList) {
+    public BoardDetailResponse toResponse(
+        BoardEntity boardEntity,
+        List<ImageResponse> imageResponseList,
+        List<CommentDetailResponse> commentDetailList
+    ) {
         return BoardDetailResponse.builder()
             .id(boardEntity.getUserId())
             .title(boardEntity.getTitle())
@@ -33,6 +38,7 @@ public class BoardConverter {
             .registeredAt(boardEntity.getRegisteredAt())
             .modifiedAt(boardEntity.getModifiedAt())
             .userId(boardEntity.getUserId())
+            .boardImage(imageResponseList)
             .commentList(commentDetailList)
             .build();
     }

--- a/board/src/main/java/board/domain/image/controller/model/ImageResponse.java
+++ b/board/src/main/java/board/domain/image/controller/model/ImageResponse.java
@@ -1,0 +1,23 @@
+package board.domain.image.controller.model;
+
+import db.domain.image.enums.ImageKind;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ImageResponse {
+
+    private Long id;
+
+    private String imageUrl;
+
+    private ImageKind kind;
+
+    private Long userId;
+
+}

--- a/board/src/main/java/board/domain/image/converter/ImageConverter.java
+++ b/board/src/main/java/board/domain/image/converter/ImageConverter.java
@@ -1,0 +1,21 @@
+package board.domain.image.converter;
+
+import board.domain.image.controller.model.ImageResponse;
+import db.domain.image.ImageEntity;
+import global.annotation.Converter;
+import lombok.extern.slf4j.Slf4j;
+
+@Converter
+@Slf4j
+public class ImageConverter {
+
+    public ImageResponse toResponse(ImageEntity imageEntity) {
+        return ImageResponse.builder()
+            .id(imageEntity.getId())
+            .imageUrl(imageEntity.getImageUrl())
+            .kind(imageEntity.getKind())
+            .userId(imageEntity.getUserId())
+            .build();
+    }
+
+}

--- a/board/src/main/java/board/domain/image/service/ImageService.java
+++ b/board/src/main/java/board/domain/image/service/ImageService.java
@@ -3,6 +3,7 @@ package board.domain.image.service;
 import board.common.error.ImageErrorCode;
 import board.common.exception.image.ImageNotFoundException;
 import db.domain.board.BoardEntity;
+import db.domain.image.ImageEntity;
 import db.domain.image.ImageRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,10 @@ public class ImageService {
                 });
             });
         }
+    }
+
+    public List<ImageEntity> getImageOrEmptyBy(Long boardId) {
+        return imageRepository.findAllByBoardIdOrderByIdAsc(boardId);
     }
 
 }

--- a/db/src/main/java/db/domain/image/ImageRepository.java
+++ b/db/src/main/java/db/domain/image/ImageRepository.java
@@ -1,5 +1,6 @@
 package db.domain.image;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +11,7 @@ public interface ImageRepository extends JpaRepository<ImageEntity, Long> {
     boolean existsByIdAndUserId(Long imageId, Long userId);
 
     Optional<ImageEntity> findFirstByPetIdOrderByIdDesc(Long petId);
+
+    List<ImageEntity> findAllByBoardIdOrderByIdAsc(Long boardId);
 
 }


### PR DESCRIPTION
# SB-97 (feat) : 단일 Board 응답에 이미지 응답 정보 추가

- `Board` 단일 조회시 `Image` 응답 정보 추가
- 이미지가 등록되지 않은 경우 `Empty []` 반환

## 변경 후 Response Spec
### 단일 조회
```
{
    "result": {
        "resultCode": 200,
        "resultMessage": "성공",
        "resultDescription": "성공"
    },
    "body": {
        "id": 5,
        "title": "string ",
        "content": "string",
        "category": "DOG",
        "status": "REGISTERED",
        "registeredAt": "2024-09-26T14:41:16.860013",
        "modifiedAt": null,
        "userId": 0,
        "commentList": [],
        "boardImage": [
            {
                "id": 0,
                "imageUrl": "string",
                "kind": "PET",
                "userId": 0
            },
            {
                "id": 0,
                "imageUrl": "string",
                "kind": "PET",
                "userId": 0
            }
        ]
    }
}
```
