### PR TITLE
SB-108 (feat) : WebConfg exclude swagger path 추가

### DIFF
--- a/board/src/main/java/board/common/config/web/WebConfig.java
+++ b/board/src/main/java/board/common/config/web/WebConfig.java
@@ -42,7 +42,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/open-api/**");
+            .excludePathPatterns("/open-api/**")
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 
 }

--- a/image/src/main/java/image/common/config/web/WebConfig.java
+++ b/image/src/main/java/image/common/config/web/WebConfig.java
@@ -47,7 +47,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/images/**"); // "/images/**" 경로는 제외
+            .excludePathPatterns("/images/**") // "/images/**" 경로는 제외
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 
     @Override

--- a/pet/src/main/java/pet/common/config/web/WebConfig.java
+++ b/pet/src/main/java/pet/common/config/web/WebConfig.java
@@ -42,7 +42,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/open-api/**");
+            .excludePathPatterns("/open-api/**")
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 
 }

--- a/user/src/main/java/user/common/config/web/WebConfig.java
+++ b/user/src/main/java/user/common/config/web/WebConfig.java
@@ -42,7 +42,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/open-api/**");
+            .excludePathPatterns("/open-api/**")
+            .excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**");
     }
 
 }


### PR DESCRIPTION

## #️⃣ Issue Number
SB-108 (feat) : WebConfg exclude swagger path 추가

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- 각 모듈별 `Swagger API Docs` 에 접근이 가능하도록 `WebConfig` 에 `excludePathPatterns("/swagger-ui/**", "/v3/api-docs/**")` 를 추가하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📑 API Spec


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



