### PR TITLE
SB-158 (refactor) : Swagger UserSession 파라미터 입력창 숨김

### DIFF
--- a/board/src/main/java/board/domain/board/controller/BoardApiController.java
+++ b/board/src/main/java/board/domain/board/controller/BoardApiController.java
@@ -9,6 +9,7 @@ import board.domain.board.controller.model.update.BoardUpdateResponse;
 import board.common.resolver.User;
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class BoardApiController {
     private final BoardBusiness boardBusiness;
 
     @PostMapping()
+    @Operation(summary = "[게시글 등록]")
     public Api<BoardRegisterResponse> register(
         @RequestBody @Valid Api<BoardRegisterRequest> request,
         @Parameter(hidden = true) @UserSession User user
@@ -35,6 +37,7 @@ public class BoardApiController {
     }
 
     @PostMapping("/unregister/{boardId}")
+    @Operation(summary = "[게시글 삭제]")
     public Api<MessageResponse> unregister(
         @PathVariable Long boardId,
         @Parameter(hidden = true) @UserSession User user) {
@@ -43,6 +46,7 @@ public class BoardApiController {
     }
 
     @PostMapping("/update")
+    @Operation(summary = "[게시글 수정]")
     public Api<BoardUpdateResponse> update(
         @RequestBody @Valid Api<BoardUpdateRequest> updateRequest,
         @Parameter(hidden = true) @UserSession User user) {

--- a/board/src/main/java/board/domain/board/controller/BoardApiController.java
+++ b/board/src/main/java/board/domain/board/controller/BoardApiController.java
@@ -9,6 +9,7 @@ import board.domain.board.controller.model.update.BoardUpdateResponse;
 import board.common.resolver.User;
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,7 @@ public class BoardApiController {
     @PostMapping()
     public Api<BoardRegisterResponse> register(
         @RequestBody @Valid Api<BoardRegisterRequest> request,
-        @UserSession User user
+        @Parameter(hidden = true) @UserSession User user
     ) {
         BoardRegisterResponse response = boardBusiness.register(request.getBody(), user.getId());
         return Api.OK(response);
@@ -36,7 +37,7 @@ public class BoardApiController {
     @PostMapping("/unregister/{boardId}")
     public Api<MessageResponse> unregister(
         @PathVariable Long boardId,
-        @UserSession User user) {
+        @Parameter(hidden = true) @UserSession User user) {
         MessageResponse response = boardBusiness.unregister(boardId, user.getId());
         return Api.OK(response);
     }
@@ -44,7 +45,7 @@ public class BoardApiController {
     @PostMapping("/update")
     public Api<BoardUpdateResponse> update(
         @RequestBody @Valid Api<BoardUpdateRequest> updateRequest,
-        @UserSession User user) {
+        @Parameter(hidden = true) @UserSession User user) {
         BoardUpdateResponse response = boardBusiness.update(updateRequest.getBody(), user.getId());
         return Api.OK(response);
     }

--- a/board/src/main/java/board/domain/board/controller/BoardOpenApiController.java
+++ b/board/src/main/java/board/domain/board/controller/BoardOpenApiController.java
@@ -5,6 +5,7 @@ import board.domain.board.controller.model.detail.BoardDetailResponse;
 import board.domain.board.controller.model.search.BoardSearchResponse;
 import board.domain.board.controller.model.search.SearchCondition;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class BoardOpenApiController {
     private final BoardBusiness boardBusiness;
 
     @GetMapping()
+    @Operation(summary = "[게시글 목록 조화/검색]")
     public Api<List<BoardSearchResponse>> getBoardSearchBy(
         @ModelAttribute @Valid SearchCondition condition,
         @PageableDefault(sort = "registeredAt", direction = Sort.Direction.DESC) Pageable page // default size = 10
@@ -34,6 +36,7 @@ public class BoardOpenApiController {
     }
 
     @GetMapping("/{boardId}")
+    @Operation(summary = "[게시글 상세 조회 + 댓글 리스트]")
     public Api<BoardDetailResponse> getBoardDetail(@PathVariable Long boardId) {
         BoardDetailResponse response = boardBusiness.getBoardDetailBy(boardId);
         return Api.OK(response);

--- a/board/src/main/java/board/domain/comment/controller/CommentController.java
+++ b/board/src/main/java/board/domain/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import board.domain.comment.controller.model.update.CommentUpdateResponse;
 import board.common.resolver.User;
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +28,7 @@ public class CommentController {
     @PostMapping()
     public Api<CommentRegisterResponse> register(
         @RequestBody @Valid Api<CommentRegisterRequest> registerRequest,
-        @UserSession User user
+        @Parameter(hidden = true) @UserSession User user
     ) {
         CommentRegisterResponse response = commentBusiness.register(registerRequest.getBody(), user.getId());
         return Api.OK(response);
@@ -36,7 +37,7 @@ public class CommentController {
     @PostMapping("/unregister/{commentId}")
     public Api<MessageResponse> unregister(
         @PathVariable Long commentId,
-        @UserSession User user
+        @Parameter(hidden = true) @UserSession User user
     ) {
         MessageResponse response = commentBusiness.unregister(commentId, user.getId());
         return Api.OK(response);
@@ -45,7 +46,7 @@ public class CommentController {
     @PostMapping("/update")
     public Api<CommentUpdateResponse> update(
         @RequestBody @Valid Api<CommentUpdateRequest> updateRequest,
-        @UserSession User user)
+        @Parameter(hidden = true) @UserSession User user)
     {
         CommentUpdateResponse response = commentBusiness.update(updateRequest.getBody(), user.getId());
         return Api.OK(response);

--- a/board/src/main/java/board/domain/comment/controller/CommentController.java
+++ b/board/src/main/java/board/domain/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import board.domain.comment.controller.model.update.CommentUpdateResponse;
 import board.common.resolver.User;
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class CommentController {
     private final CommentBusiness commentBusiness;
 
     @PostMapping()
+    @Operation(summary = "[댓글 등록]")
     public Api<CommentRegisterResponse> register(
         @RequestBody @Valid Api<CommentRegisterRequest> registerRequest,
         @Parameter(hidden = true) @UserSession User user
@@ -35,6 +37,7 @@ public class CommentController {
     }
 
     @PostMapping("/unregister/{commentId}")
+    @Operation(summary = "[댓글 삭제]")
     public Api<MessageResponse> unregister(
         @PathVariable Long commentId,
         @Parameter(hidden = true) @UserSession User user
@@ -44,6 +47,7 @@ public class CommentController {
     }
 
     @PostMapping("/update")
+    @Operation(summary = "[댓글 수정]")
     public Api<CommentUpdateResponse> update(
         @RequestBody @Valid Api<CommentUpdateRequest> updateRequest,
         @Parameter(hidden = true) @UserSession User user)

--- a/image/src/main/java/image/domain/image/controller/ImageApiController.java
+++ b/image/src/main/java/image/domain/image/controller/ImageApiController.java
@@ -7,6 +7,7 @@ import image.domain.image.controller.model.ImageRequest;
 import image.domain.image.controller.model.ImageResponse;
 import image.common.resolver.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +24,10 @@ public class ImageApiController {
 
     @PostMapping()
     @Operation(summary = "[단일 이미지 Upload]")
-    public Api<ImageResponse> upload(ImageRequest imageRequest, @UserSession User user) {
+    public Api<ImageResponse> upload(
+        ImageRequest imageRequest,
+        @Parameter(hidden = true) @UserSession User user
+    ) {
         ImageResponse response = imageBusiness.uploadImage(imageRequest, user.getId());
         return Api.OK(response);
     }

--- a/pet/src/main/java/pet/domain/pet/controller/PetApiController.java
+++ b/pet/src/main/java/pet/domain/pet/controller/PetApiController.java
@@ -2,6 +2,7 @@ package pet.domain.pet.controller;
 
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +31,17 @@ public class PetApiController {
     @PostMapping()
     public Api<PetRegisterResponse> register(
         @RequestBody @Valid Api<PetRegisterRequest> registerRequest,
-        @UserSession User user
+        @Parameter(hidden = true) @UserSession User user
     ) {
         PetRegisterResponse response = petBusiness.register(registerRequest.getBody(), user.getId());
         return Api.OK(response);
     }
 
     @PostMapping("/unregister/{petId}")
-    public Api<MessageResponse> unregister(@PathVariable Long petId, @UserSession User user) {
+    public Api<MessageResponse> unregister(
+        @PathVariable Long petId,
+        @Parameter(hidden = true) @UserSession User user
+    ) {
         MessageResponse response = petBusiness.unregister(petId, user.getId());
         return Api.OK(response);
     }
@@ -45,20 +49,23 @@ public class PetApiController {
     @PostMapping("/update")
     public Api<MessageResponse> update(
         @RequestBody  @Valid Api<PetUpdateRequest> petUpdateRequest,
-        @UserSession User user
+        @Parameter(hidden = true) @UserSession User user
     ) {
         MessageResponse response = petBusiness.update(petUpdateRequest.getBody(), user.getId());
         return Api.OK(response);
     }
 
     @GetMapping("/{petId}")
-    public Api<PetDetailResponse> getPet(@PathVariable Long petId, @UserSession User user) {
+    public Api<PetDetailResponse> getPet(
+        @PathVariable Long petId,
+        @Parameter(hidden = true) @UserSession User user
+    ) {
         PetDetailResponse response = petBusiness.getPetBy(petId, user.getId());
         return Api.OK(response);
     }
 
     @GetMapping()
-    public Api<List<PetListResponse>> getPetList(@UserSession User user) {
+    public Api<List<PetListResponse>> getPetList(@Parameter(hidden = true) @UserSession User user) {
         List<PetListResponse> response = petBusiness.getPetListBy(user.getId());
         return Api.OK(response);
     }

--- a/pet/src/main/java/pet/domain/pet/controller/PetApiController.java
+++ b/pet/src/main/java/pet/domain/pet/controller/PetApiController.java
@@ -2,6 +2,7 @@ package pet.domain.pet.controller;
 
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -29,6 +30,7 @@ public class PetApiController {
     private final PetBusiness petBusiness;
 
     @PostMapping()
+    @Operation(summary = "[반려동물 등록]")
     public Api<PetRegisterResponse> register(
         @RequestBody @Valid Api<PetRegisterRequest> registerRequest,
         @Parameter(hidden = true) @UserSession User user
@@ -38,6 +40,7 @@ public class PetApiController {
     }
 
     @PostMapping("/unregister/{petId}")
+    @Operation(summary = "[반려동물 삭제]")
     public Api<MessageResponse> unregister(
         @PathVariable Long petId,
         @Parameter(hidden = true) @UserSession User user
@@ -47,6 +50,7 @@ public class PetApiController {
     }
 
     @PostMapping("/update")
+    @Operation(summary = "[반려동물 수정]")
     public Api<MessageResponse> update(
         @RequestBody  @Valid Api<PetUpdateRequest> petUpdateRequest,
         @Parameter(hidden = true) @UserSession User user
@@ -56,6 +60,7 @@ public class PetApiController {
     }
 
     @GetMapping("/{petId}")
+    @Operation(summary = "[반려동물 단일 조회]")
     public Api<PetDetailResponse> getPet(
         @PathVariable Long petId,
         @Parameter(hidden = true) @UserSession User user
@@ -65,6 +70,7 @@ public class PetApiController {
     }
 
     @GetMapping()
+    @Operation(summary = "[반려동물 목록 조회]")
     public Api<List<PetListResponse>> getPetList(@Parameter(hidden = true) @UserSession User user) {
         List<PetListResponse> response = petBusiness.getPetListBy(user.getId());
         return Api.OK(response);

--- a/pet/src/main/java/pet/domain/vaccination/controller/VaccinationApiController.java
+++ b/pet/src/main/java/pet/domain/vaccination/controller/VaccinationApiController.java
@@ -2,6 +2,7 @@ package pet.domain.vaccination.controller;
 
 import global.annotation.UserSession;
 import global.api.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -26,6 +27,7 @@ public class VaccinationApiController {
     private final VaccinationBusiness vaccinationBusiness;
 
     @PostMapping()
+    @Operation(summary = "[예방접종 기록 등록]")
     public Api<VaccinationResponse> register(
         @RequestBody @Valid Api<VaccinationRequest> registerRequest,
         @Parameter(hidden = true) @UserSession User user
@@ -36,6 +38,7 @@ public class VaccinationApiController {
     }
 
     @GetMapping("/{petId}")
+    @Operation(summary = "[예방접종 기록 목록 상세 조회]")
     public Api<List<VaccinationDetailResponse>> getVaccinationRecordList(
         @PathVariable Long petId,
         @Parameter(hidden = true) @UserSession User user

--- a/user/src/main/java/user/domain/user/controller/UserApiController.java
+++ b/user/src/main/java/user/domain/user/controller/UserApiController.java
@@ -23,16 +23,14 @@ public class UserApiController {
 
     @GetMapping()
     @Operation(summary = "[회원 정보 조회]")
-    public Api<UserResponse> getUserInformation(
-        @Parameter(hidden = true) @UserSession User user) {
+    public Api<UserResponse> getUserInformation(@Parameter(hidden = true) @UserSession User user) {
         UserResponse response = userBusiness.getUserInformation(user.getId());
         return Api.OK(response);
     }
 
     @PostMapping("/unregister")
     @Operation(summary = "[회원 탈퇴]")
-    public Api<MessageResponse> unregister(
-        @Parameter(hidden = true) @UserSession User user) {
+    public Api<MessageResponse> unregister(@Parameter(hidden = true) @UserSession User user) {
         MessageResponse response = userBusiness.unregister(user.getId());
         return Api.OK(response);
     }


### PR DESCRIPTION

- `@Parameter(hidden=true) @UserSession User user` 으로 해결

## #️⃣ Issue Number

SB-158 (refactor) : Swagger UserSession 파라미터 입력창 숨김
## 📝 요약(Summary)

- 요청 시 UserSession 의 파라미터 입력창이 나오는 것을 해결하기 위해 `Parameter(hidden=true)` 메서드 사용
- 부가적으로 모든 요청에 설명 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📑 API Spec

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)



